### PR TITLE
Update CUDA runtime version to 8.0

### DIFF
--- a/combine/Makefile
+++ b/combine/Makefile
@@ -17,5 +17,5 @@ LINKCUFILES := stencilMVM.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/combine/combine.64.cu
+++ b/combine/combine.64.cu
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 
 #define XBLOCK 32
 

--- a/combine/combine.cu
+++ b/combine/combine.cu
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 
 #define TEXTON32 1
 #define TEXTON64 2

--- a/combine/combinemain.cu
+++ b/combine/combinemain.cu
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include "combine.h"
 #include "stencilMVM.h"
 

--- a/combine/common.mk
+++ b/combine/common.mk
@@ -82,7 +82,7 @@ CWARN_FLAGS := $(CXXWARN_FLAGS) \
 	-Wmain \
 
 # Compiler-specific flags
-NVCCFLAGS := -arch sm_12 -Xptxas -v -maxrregcount 32
+NVCCFLAGS := -arch sm_35 -Xptxas -v -maxrregcount 32
 CXXFLAGS  := $(CXXWARN_FLAGS)
 CFLAGS    := $(CWARN_FLAGS)
 

--- a/common.mk
+++ b/common.mk
@@ -123,7 +123,7 @@ ifeq ($(shared),1)
 endif
 
 # append optional arch/SM version flags (such as -arch sm_11)
-SMVERSIONFLAGS ?= -arch sm_12
+SMVERSIONFLAGS ?= -arch sm_35
 #SMVERSIONFLAGS ?= -arch sm_11
 NVCCFLAGS += $(SMVERSIONFLAGS)
 

--- a/common.mk
+++ b/common.mk
@@ -14,7 +14,7 @@ endif
 
 
 
-CUDA_SDK_PATH ?= $(HOME)/cuda
+CUDA_SDK_PATH ?= /usr/local/cuda/samples
 
 # Basic directory setup for SDK
 # (override directories only if they are not already defined)
@@ -26,9 +26,9 @@ ROOTOBJDIR ?= $(ROOTDIR)/obj
 ROOTSODIR  ?= $(ROOTDIR)/lib
 SODIR      ?= $(ROOTSODIR)/linux
 
-LIBDIR     := $(CUDA_SDK_PATH)/C/lib 
-COMMONDIR  := $(CUDA_SDK_PATH)/C/common
-ACMLDIR    ?= /opt/amd/acml4.3.0/ifort64
+LIBDIR     := $(CUDA_SDK_PATH)/common/lib
+COMMONDIR  := $(CUDA_SDK_PATH)/common
+ACMLDIR    ?= $(ROOTSODIR)/acml/ifort64
 
 ifdef cuda-2.1
   CUDALIBSUFFIX := lib
@@ -67,7 +67,7 @@ ifeq ($(USEGLLIB),1)
 endif
 
 # Libs
-LIB       := -L$(CUDA_INSTALL_PATH)/$(CUDALIBSUFFIX) -L$(LIBDIR) -L$(COMMONDIR)/lib -L$(ACMLDIR)/lib -lcuda -lcudart -lcublas -lblas -lacml -lacml_mv -L../stencilMatrixMultiply/lib/linux/release ${OPENGLLIB} ${LIB}
+LIB       := -L$(CUDA_INSTALL_PATH)/$(CUDALIBSUFFIX) -L$(LIBDIR) -L$(COMMONDIR)/lib -L$(ACMLDIR)/lib -L$(ROOTSODIR) -lcuda -lcudart -lcublas -lblas -lacml -L../stencilMatrixMultiply/lib/linux/release ${OPENGLLIB} ${LIB}
 
 # Warning flags
 CXXWARN_FLAGS := \
@@ -160,7 +160,7 @@ ifneq ($(STATIC_LIB),)
 	TARGET   := $(subst .a,$(LIBSUFFIX).a,$(LIBDIR)/$(STATIC_LIB))
 	LINKLINE  = ar qv $(TARGET) $(OBJS) 
 else
-	LIB += -lcutil$(LIBSUFFIX)
+	#LIB += -lcutil$(LIBSUFFIX)
 	# Device emulation configuration
 	ifeq ($(emu), 1)
 		NVCCFLAGS   += -deviceemu

--- a/convert/Makefile
+++ b/convert/Makefile
@@ -17,5 +17,5 @@ LINKCUFILES := stencilMVM.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/convert/common.mk
+++ b/convert/common.mk
@@ -82,7 +82,7 @@ CWARN_FLAGS := $(CXXWARN_FLAGS) \
 	-Wmain \
 
 # Compiler-specific flags
-NVCCFLAGS := -arch sm_12 -Xptxas -v -maxrregcount 32
+NVCCFLAGS := -arch sm_35 -Xptxas -v -maxrregcount 32
 CXXFLAGS  := $(CXXWARN_FLAGS)
 CFLAGS    := $(CWARN_FLAGS)
 

--- a/convert/convert.cu
+++ b/convert/convert.cu
@@ -3,7 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
+#include <helper_image.h>
+#include "Stencil.h"
 
 #define XBLOCK 16
 #define YBLOCK 16
@@ -87,7 +89,7 @@ __global__ void normalizeLab_kernel(uint width, uint height, float* devL, float*
 
 void loadPPM_rgbU(char* filename, uint* p_width, uint* p_height, uint** p_devRgbU) {
   unsigned int* data;
-  cutLoadPPM4ub(filename, (unsigned char**)&data, p_width, p_height);
+  sdkLoadPPM4ub(filename, (unsigned char**)&data, p_width, p_height);
   //cutLoadPPMub(filename, (unsigned char**)&data, p_width, p_height);
   uint imageSize = sizeof(uint) * (*p_width) * (*p_height);
   cudaMalloc((void**)p_devRgbU, imageSize);
@@ -108,7 +110,7 @@ void rgbUtoGreyF(uint width, uint height, uint* devRgbU, float** p_devGrey) {
   dim3 gridDim = dim3((width - 1)/XBLOCK + 1, (height - 1)/YBLOCK + 1);
   dim3 blockDim = dim3(XBLOCK, YBLOCK);
   uint imageSize = sizeof(float) * width * height;
-  CUDA_SAFE_CALL(cudaMalloc((void**)p_devGrey, imageSize));
+  checkCudaErrors(cudaMalloc((void**)p_devGrey, imageSize));
   rgbUtoGreyF_kernel<<<gridDim, blockDim>>>(width, height, devRgbU, *p_devGrey);
 }
 

--- a/convert/convertmain.cu
+++ b/convert/convertmain.cu
@@ -3,19 +3,20 @@
 #include <stdlib.h>
 #include "convert.h"
 #include "stencilMVM.h"
-#include <cutil.h>
+#include <helper_cuda.h>
+#include <helper_image.h>
 
 float* getImage(uint width, uint height, float* devImage) {
   int imageSize = width * height * sizeof(float);
   float* result = (float*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
 int* getImage(uint width, uint height, int* devImage) {
   int imageSize = width * height * sizeof(int);
   int* result = (int*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
@@ -50,7 +51,8 @@ int main(int argc, char** argv) {
   unsigned int height;
   unsigned int* devRgbU;
   loadPPM_rgbU(filename, &width, &height, &devRgbU);
-  printf("Width: %i, height: %i\n", width, height, devRgbU);
+  //printf("Width: %i, height: %i\n", width, height, devRgbU);
+  printf("Width: %i, height: %i\n", width, height);
   float* devL;
   float* devA;
   float* devB;
@@ -73,8 +75,8 @@ int main(int argc, char** argv) {
   int borderHeight = 2 * border + height;
   float* borderedGrey = getImage(borderWidth, borderHeight, devBorderedGrey);
   writeTextImage("borderedGrey.txt", borderWidth, borderHeight, borderedGrey);
-  cutSavePGMf("borderedGrey.pgm", borderedGrey, borderWidth, borderHeight);
-  cutSavePGMf("grey.pgm", grey, width, height);
+  sdkSavePGM("borderedGrey.pgm", borderedGrey, borderWidth, borderHeight);
+  sdkSavePGM("grey.pgm", grey, width, height);
   int* devQuantizedBorderedGrey;
   quantizeImage(borderWidth, borderHeight, 25, devBorderedGrey, &devQuantizedBorderedGrey);
   int* quantizedBorderedGrey = getImage(borderWidth, borderHeight, devQuantizedBorderedGrey);

--- a/damascene/Makefile
+++ b/damascene/Makefile
@@ -18,5 +18,5 @@ LINKCCFILES := Stencil.cpp filters.cpp
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/damascene/common.mk
+++ b/damascene/common.mk
@@ -83,7 +83,7 @@ CWARN_FLAGS := $(CXXWARN_FLAGS) \
 	-Wmain \
 
 # Compiler-specific flags
-NVCCFLAGS := -arch sm_12 -Xptxas -v
+NVCCFLAGS := -arch sm_35 -Xptxas -v
 CXXFLAGS  := $(CXXWARN_FLAGS)
 CFLAGS    := $(CWARN_FLAGS)
 

--- a/damascene/common.mk
+++ b/damascene/common.mk
@@ -26,7 +26,7 @@ SODIR      ?= $(ROOTSODIR)/linux
 
 LIBDIR     := $(CUDA_SDK_PATH)/lib 
 COMMONDIR  := $(CUDA_SDK_PATH)/common
-ACMLDIR    := /opt/amd/acml4.1.0/ifort64
+ACMLDIR    := $(ROOTSODIR)/acml/ifort64
 
 # Compilers
 NVCC       := nvcc 

--- a/damascene/damascene.cu
+++ b/damascene/damascene.cu
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
   int nTextonChoice = TEXTON32;
 
   parsingCommand(argc, argv, nEigNum, fEigTolerance, nTextonChoice);
-  printf("\n Eig %d Tol %f Texton %d", nEigNum, fEigTolerance, nTextonChoice);
+  printf("\nEig %d Tol %f Texton %d\n", nEigNum, fEigTolerance, nTextonChoice);
 
   
   uint width;

--- a/gPb/Makefile
+++ b/gPb/Makefile
@@ -18,5 +18,5 @@ LINKCUFILES :=
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/gPb/gpbmain.cu
+++ b/gPb/gpbmain.cu
@@ -1,6 +1,6 @@
 // vim: ts=4 syntax=cpp comments=
 
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <cuda.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,8 +33,8 @@ void chooseLargestGPU(bool verbose)
 void dummy()
 {
 	float* test;
-	CUDA_SAFE_CALL(cudaMalloc((void**)&test, 100 * sizeof(float)));
-	CUDA_SAFE_CALL(cudaFree(test));
+	checkCudaErrors(cudaMalloc((void**)&test, 100 * sizeof(float)));
+	checkCudaErrors(cudaFree(test));
 }
 
 size_t ReadOneMatrix(FILE* infile, float** devArray, int orient)
@@ -53,17 +53,17 @@ size_t ReadOneMatrix(FILE* infile, float** devArray, int orient)
 	size_t pitch = 0;
 	if (orient > 1)
 	{
-		CUDA_SAFE_CALL(cudaMallocPitch((void**)devArray, &pitch, 154401 *  sizeof(float), orient));
+		checkCudaErrors(cudaMallocPitch((void**)devArray, &pitch, 154401 *  sizeof(float), orient));
 		pitch/=sizeof(float);
 		for (int i = 0; i < orient; i++)
 		{
-			CUDA_SAFE_CALL(cudaMemcpy((*devArray)+i*pitch, tempArray+i*154401, 154401 * sizeof(float), cudaMemcpyHostToDevice));
+			checkCudaErrors(cudaMemcpy((*devArray)+i*pitch, tempArray+i*154401, 154401 * sizeof(float), cudaMemcpyHostToDevice));
 		}
 	}
 	else
 	{
-		CUDA_SAFE_CALL(cudaMalloc((void**)devArray, 154401 * sizeof(float)));
-		CUDA_SAFE_CALL(cudaMemcpy((*devArray), tempArray, 154401 * sizeof(float), cudaMemcpyHostToDevice));
+		checkCudaErrors(cudaMalloc((void**)devArray, 154401 * sizeof(float)));
+		checkCudaErrors(cudaMemcpy((*devArray), tempArray, 154401 * sizeof(float), cudaMemcpyHostToDevice));
 	}
 	//printf("\n Pitch %d ", pitch);
 	return pitch;
@@ -116,20 +116,20 @@ void ClearAllMemory(
 		float* devspb,
 		float* devmpb)
 {
-	CUDA_SAFE_CALL(cudaFree(devbg1));
-	CUDA_SAFE_CALL(cudaFree(devbg2));
-	CUDA_SAFE_CALL(cudaFree(devbg3));
-	CUDA_SAFE_CALL(cudaFree(devcga1));
-	CUDA_SAFE_CALL(cudaFree(devcga2));
-	CUDA_SAFE_CALL(cudaFree(devcga3));
-	CUDA_SAFE_CALL(cudaFree(devcgb1));
-	CUDA_SAFE_CALL(cudaFree(devcgb2));
-	CUDA_SAFE_CALL(cudaFree(devcgb3));
-	CUDA_SAFE_CALL(cudaFree(devtg1));
-	CUDA_SAFE_CALL(cudaFree(devtg2));
-	CUDA_SAFE_CALL(cudaFree(devtg3));
-	CUDA_SAFE_CALL(cudaFree(devspb));
-	CUDA_SAFE_CALL(cudaFree(devmpb));
+	checkCudaErrors(cudaFree(devbg1));
+	checkCudaErrors(cudaFree(devbg2));
+	checkCudaErrors(cudaFree(devbg3));
+	checkCudaErrors(cudaFree(devcga1));
+	checkCudaErrors(cudaFree(devcga2));
+	checkCudaErrors(cudaFree(devcga3));
+	checkCudaErrors(cudaFree(devcgb1));
+	checkCudaErrors(cudaFree(devcgb2));
+	checkCudaErrors(cudaFree(devcgb3));
+	checkCudaErrors(cudaFree(devtg1));
+	checkCudaErrors(cudaFree(devtg2));
+	checkCudaErrors(cudaFree(devtg3));
+	checkCudaErrors(cudaFree(devspb));
+	checkCudaErrors(cudaFree(devmpb));
 }
 
 void StartGlobalPb()
@@ -154,16 +154,16 @@ void StartGlobalPb()
 	float* hostResult = (float*)malloc(154401*sizeof(float));
 	int pitch = 0;
 
-	CUDA_SAFE_CALL(cudaMalloc((void**)&result, 154401 * sizeof(float)));
+	checkCudaErrors(cudaMalloc((void**)&result, 154401 * sizeof(float)));
 
 	ReadFromFile(&pitch, &bg1, &bg2, &bg3, &cga1, &cga2, &cga3, &cgb1, &cgb2, &cgb3, &tg1, &tg2, &tg3, &spb, &mpb);
 	//printf("\nPitch = %d\n", pitch);
 	//StartCalcGPb(154401, pitch, 8, bg1, bg2, bg3, cga1, cga2, cga3, cgb1, cgb2, cgb3, tg1, tg2, tg3, spb, mpb, result);
 
-	CUDA_SAFE_CALL(cudaMemcpy(hostResult, result, 154401 * sizeof(float), cudaMemcpyDeviceToHost));
+	checkCudaErrors(cudaMemcpy(hostResult, result, 154401 * sizeof(float), cudaMemcpyDeviceToHost));
 
 	ClearAllMemory(bg1, bg2, bg3, cga1, cga2, cga3, cgb1, cgb2, cgb3, tg1, tg2, tg3, spb, mpb);
-	CUDA_SAFE_CALL(cudaFree(result));
+	checkCudaErrors(cudaFree(result));
 
 	for (int i = 0; i < 481; i++)
 	{

--- a/include/globalPb.h
+++ b/include/globalPb.h
@@ -1,7 +1,7 @@
 #ifndef GLOBALPB
 #define GLOBALPB
 
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <cuda.h>
 
 #define IMUL(a, b) __mul24(a, b)

--- a/include/stencilMVM.h
+++ b/include/stencilMVM.h
@@ -1,5 +1,5 @@
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/include/stencilMVM.h
+++ b/include/stencilMVM.h
@@ -1,5 +1,6 @@
 #include <cuda.h>
 #include <helper_cuda.h>
+#include <helper_timer.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/intervening/Makefile
+++ b/intervening/Makefile
@@ -17,5 +17,5 @@ LINKCUFILES := stencilMVM.cu #combine.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/intervening/interveningmain.cu
+++ b/intervening/interveningmain.cu
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <assert.h>
 #include "intervening.h"
 #include "stencilMVM.h"
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
 /*   printf("\n"); */
 
   
-  /* CUDA_SAFE_CALL(cudaMemcpy(hostMatrix, devMatrix, devMatrixPitch * nDimension, cudaMemcpyDeviceToHost)); */
+  /* checkCudaErrors(cudaMemcpy(hostMatrix, devMatrix, devMatrixPitch * nDimension, cudaMemcpyDeviceToHost)); */
   /* int row = 3; */
 /*   int col = 6; */
 /*   printf("row: %i, col %i\n", row, col); */
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 /*   } */
 /*   printf("\n"); */
   
-  CUDA_SAFE_CALL(cudaMemcpy(hostMatrix, devMatrix, devMatrixPitch * nDimension, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(hostMatrix, devMatrix, devMatrixPitch * nDimension, cudaMemcpyDeviceToHost));
 /*   row = 3; */
 /*   col = 6; */
 /*   printf("row: %i, col %i\n", row, col); */

--- a/localcues/Makefile
+++ b/localcues/Makefile
@@ -20,5 +20,5 @@ LINKCUFILES := stencilMVM.cu convert.cu texton.cu kmeans.cu combine.cu
 
 verbose := 1
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/localcues/common.mk
+++ b/localcues/common.mk
@@ -111,7 +111,7 @@ CWARN_FLAGS := $(CXXWARN_FLAGS) \
 
 # Compiler-specific flags
 #NVCCFLAGS := -Xptxas -v
-NVCCFLAGS:= -arch sm_12 -Xptxas -v
+NVCCFLAGS := -arch sm_35 -Xptxas -v
 CXXFLAGS  := $(CXXWARN_FLAGS)
 CFLAGS    := $(CWARN_FLAGS)
 

--- a/localcues/gradient.64.cu
+++ b/localcues/gradient.64.cu
@@ -1,13 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <cuda.h>
 #include "rotate.h"
 #include "convert.h"
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <assert.h>
 
 
@@ -393,9 +393,9 @@ void formIntegralImages(int width, int height, int nbins, int* devImage,
   //cutStartTimer(integralTimer);
   //int pixelPitch = findPitchInInts(width * height);
   //int* devIntegralCol;
-  //CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegralCol, sizeof(int) * width * height));
+  //checkCudaErrors(cudaMalloc((void**)&devIntegralCol, sizeof(int) * width * height));
   //int* devIntegralsT;
-  //CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegralsT, sizeof(int) * pixelPitch * nbins));
+  //checkCudaErrors(cudaMalloc((void**)&devIntegralsT, sizeof(int) * pixelPitch * nbins));
  
   //int* hostIntegralCol = (int*)malloc(sizeof(int) * width * height);
   //int* devImageT;
@@ -459,14 +459,14 @@ void formIntegralImages(int width, int height, int nbins, int* devImage,
 float* getImage(uint width, uint height, float* devImage) {
   int imageSize = width * height * sizeof(float);
   float* result = (float*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
 int* getImage(uint width, uint height, int* devImage) {
   int imageSize = width * height * sizeof(int);
   int* result = (int*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
@@ -510,11 +510,11 @@ int initializeGradients(uint widthIn, uint heightIn, uint borderIn, uint maxbins
   borderWidth = width + 2 * border;
   borderHeight = height + 2 * border;
   
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradients, sizeof(float) * norients * nscale * borderWidth * borderHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devQuantized, sizeof(int) * width * height));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devMirrored, sizeof(int) * borderWidth * borderHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradientA, sizeof(float) * width * height));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradientB, sizeof(float) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devGradients, sizeof(float) * norients * nscale * borderWidth * borderHeight));
+  checkCudaErrors(cudaMalloc((void**)&devQuantized, sizeof(int) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devMirrored, sizeof(int) * borderWidth * borderHeight));
+  checkCudaErrors(cudaMalloc((void**)&devGradientA, sizeof(float) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devGradientB, sizeof(float) * width * height));
 
   int maxWidth = borderWidth + borderHeight;
   int maxHeight = maxWidth;
@@ -524,28 +524,28 @@ int initializeGradients(uint widthIn, uint heightIn, uint borderIn, uint maxbins
   
 
   
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devTurned, sizeof(int) * maxWidth * maxHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devImageT, sizeof(int) * maxWidth * maxHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegralCol, sizeof(int) * maxWidth * maxHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegralColT, sizeof(int) * maxWidth * maxHeight));
-  //CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegralsT, sizeof(int) * pixelPitch * maxBins));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegrals, sizeof(int) * binPitch * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devTurned, sizeof(int) * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devImageT, sizeof(int) * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devIntegralCol, sizeof(int) * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devIntegralColT, sizeof(int) * maxWidth * maxHeight));
+  //checkCudaErrors(cudaMalloc((void**)&devIntegralsT, sizeof(int) * pixelPitch * maxBins));
+  checkCudaErrors(cudaMalloc((void**)&devIntegrals, sizeof(int) * binPitch * maxWidth * maxHeight));
   return binPitch;
 }
 
 
 void finalizeGradients() {
-  CUDA_SAFE_CALL(cudaFree(devIntegrals));
- /*  CUDA_SAFE_CALL(cudaFree(devIntegralsT)); */
-  CUDA_SAFE_CALL(cudaFree(devIntegralColT));
-  CUDA_SAFE_CALL(cudaFree(devIntegralCol));
-  CUDA_SAFE_CALL(cudaFree(devImageT));
-  CUDA_SAFE_CALL(cudaFree(devTurned));
-  CUDA_SAFE_CALL(cudaFree(devGradientB));
-  CUDA_SAFE_CALL(cudaFree(devGradientA));
-  CUDA_SAFE_CALL(cudaFree(devMirrored));
-  CUDA_SAFE_CALL(cudaFree(devQuantized));
-  CUDA_SAFE_CALL(cudaFree(devGradients));
+  checkCudaErrors(cudaFree(devIntegrals));
+ /*  checkCudaErrors(cudaFree(devIntegralsT)); */
+  checkCudaErrors(cudaFree(devIntegralColT));
+  checkCudaErrors(cudaFree(devIntegralCol));
+  checkCudaErrors(cudaFree(devImageT));
+  checkCudaErrors(cudaFree(devTurned));
+  checkCudaErrors(cudaFree(devGradientB));
+  checkCudaErrors(cudaFree(devGradientA));
+  checkCudaErrors(cudaFree(devMirrored));
+  checkCudaErrors(cudaFree(devQuantized));
+  checkCudaErrors(cudaFree(devGradients));
 }
 
 

--- a/localcues/gradient.cu
+++ b/localcues/gradient.cu
@@ -1,13 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <cuda.h>
 #include "rotate.h"
 #include "convert.h"
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <assert.h>
 
 
@@ -122,14 +122,14 @@ void formIntegralImages(int width, int height, int nbins, int* devImage,
 float* getImage(uint width, uint height, float* devImage) {
   int imageSize = width * height * sizeof(float);
   float* result = (float*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
 int* getImage(uint width, uint height, int* devImage) {
   int imageSize = width * height * sizeof(int);
   int* result = (int*)malloc(imageSize);
-  CUDA_SAFE_CALL(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(result, devImage, imageSize, cudaMemcpyDeviceToHost));
   return result;
 }
 
@@ -173,11 +173,11 @@ int initializeGradients(uint widthIn, uint heightIn, uint borderIn, uint maxbins
   borderWidth = width + 2 * border;
   borderHeight = height + 2 * border;
   
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradients, sizeof(float) * norients * nscale * borderWidth * borderHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devQuantized, sizeof(int) * width * height));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devMirrored, sizeof(int) * borderWidth * borderHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradientA, sizeof(float) * width * height));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devGradientB, sizeof(float) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devGradients, sizeof(float) * norients * nscale * borderWidth * borderHeight));
+  checkCudaErrors(cudaMalloc((void**)&devQuantized, sizeof(int) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devMirrored, sizeof(int) * borderWidth * borderHeight));
+  checkCudaErrors(cudaMalloc((void**)&devGradientA, sizeof(float) * width * height));
+  checkCudaErrors(cudaMalloc((void**)&devGradientB, sizeof(float) * width * height));
 
   int maxWidth = borderWidth + borderHeight;
   int maxHeight = maxWidth;
@@ -189,20 +189,20 @@ int initializeGradients(uint widthIn, uint heightIn, uint borderIn, uint maxbins
   
 
   
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devTurned, sizeof(int) * maxWidth * maxHeight));
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devIntegrals, sizeof(int) * binPitch * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devTurned, sizeof(int) * maxWidth * maxHeight));
+  checkCudaErrors(cudaMalloc((void**)&devIntegrals, sizeof(int) * binPitch * maxWidth * maxHeight));
   return binPitch;
 }
 
 
 void finalizeGradients() {
-  CUDA_SAFE_CALL(cudaFree(devIntegrals));
-  CUDA_SAFE_CALL(cudaFree(devTurned));
-  CUDA_SAFE_CALL(cudaFree(devGradientB));
-  CUDA_SAFE_CALL(cudaFree(devGradientA));
-  CUDA_SAFE_CALL(cudaFree(devMirrored));
-  CUDA_SAFE_CALL(cudaFree(devQuantized));
-  CUDA_SAFE_CALL(cudaFree(devGradients));
+  checkCudaErrors(cudaFree(devIntegrals));
+  checkCudaErrors(cudaFree(devTurned));
+  checkCudaErrors(cudaFree(devGradientB));
+  checkCudaErrors(cudaFree(devGradientA));
+  checkCudaErrors(cudaFree(devMirrored));
+  checkCudaErrors(cudaFree(devQuantized));
+  checkCudaErrors(cudaFree(devGradients));
 }
 
 

--- a/localcues/localcues.64.cu
+++ b/localcues/localcues.64.cu
@@ -251,29 +251,28 @@ void localCues(int width, int height, float* devL, float* devA, float* devB, int
   gpu_parabola_init(norients, width, height, border);
 
   
-  uint cueTimer;
-  cutCreateTimer(&cueTimer);
-  cutStartTimer(cueTimer);
+  StopWatchInterface *cueTimer=NULL;
+  sdkCreateTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   bg(width, height, norients, nscale, &radii[0], &filters[0], devL, devBg, cuePitchInFloats);
-  cutStopTimer(cueTimer);
-  printf("\tBg: %f ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf("\tBg: %f ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   cg(width, height, norients, nscale, &radii[1], &filters[1], devA, devCga, cuePitchInFloats);
-  cutStopTimer(cueTimer);
-  printf("\tCga: %f ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf("\tCga: %f ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   cg(width, height, norients, nscale, &radii[1], &filters[1], devB, devCgb, cuePitchInFloats);
-  cutStopTimer(cueTimer);
-  printf("\tCgb: %f ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf("\tCgb: %f ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   tg(width, height, norients, nscale, &radii[1], &filters[1], devTextons, devTg, cuePitchInFloats);
-  cutStopTimer(cueTimer);
-  printf("\tTg: %f ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
- 
+  sdkStopTimer(&cueTimer);
+  printf("\tTg: %f ms\n", sdkGetTimerValue(&cueTimer));
+  sdkDeleteTimer(&cueTimer);
   cudaThreadSynchronize();
   finalizeGradients();
   gpu_parabola_cleanup();

--- a/localcues/localcues.cu
+++ b/localcues/localcues.cu
@@ -184,16 +184,17 @@ void bg(uint width, uint height, uint norients, uint nscale, uint* bgRadii, floa
   uint borderWidth = width + 2 * border;
   uint borderHeight = height + 2 * border;
   float* devGradients = gradients(devL, nbins, blur, sigma, bgRadii, textonChoice);
-  uint cueTimer;
-  cutCreateTimer(&cueTimer);
-  cutStartTimer(cueTimer);
+  StopWatchInterface *cueTimer=NULL;
+  sdkCreateTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   for(int scale = 0; scale < nscale; scale++) {
     int radius = bgRadii[scale];
     int length = 2*radius + 1;
     gpu_parabola(norients, width, height, border, &devGradients[borderWidth * borderHeight * norients * scale], radius, length, filters[scale], devBg + cuePitchInFloats * norients * scale, cuePitchInFloats);
   }
-  cutStopTimer(cueTimer);
-  printf(">+< \tBgsmooth: | %f | ms\n", cutGetTimerValue(cueTimer));
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tBgsmooth: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkDeleteTimer(&cueTimer);
 }
 
 void cg(uint width, uint height, uint norients, uint nscale, uint* cgRadii, float** filters, float* devInput, float** p_devCg, int cuePitchInFloats, int textonChoice)
@@ -211,16 +212,17 @@ void cg(uint width, uint height, uint norients, uint nscale, uint* cgRadii, floa
   uint borderHeight = height + 2 * border;
   
   float* devGradients = gradients(devInput, nbins, blur, sigma, cgRadii, textonChoice);
-  uint cueTimer;
-  cutCreateTimer(&cueTimer);
-  cutStartTimer(cueTimer);
+  StopWatchInterface *cueTimer=NULL;
+  sdkCreateTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   for(int scale = 0; scale < nscale; scale++) {
     int radius = cgRadii[scale];
     int length = 2*radius + 1;
     gpu_parabola(norients, width, height, border, &devGradients[borderWidth * borderHeight * norients * scale], radius, length, filters[scale], devCg + cuePitchInFloats * norients * scale, cuePitchInFloats);
   }
-  cutStopTimer(cueTimer);
-  printf(">+< \tCgsmooth: | %f | ms\n", cutGetTimerValue(cueTimer));
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tCgsmooth: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkDeleteTimer(&cueTimer);
 }
 
 void tg(uint width, uint height, uint norients, uint nscale, uint* tgRadii, float** filters, int* devTextons, float** p_devTg, int cuePitchInFloats, int textonChoice)
@@ -241,16 +243,17 @@ void tg(uint width, uint height, uint norients, uint nscale, uint* tgRadii, floa
   uint borderHeight = height + 2 * border;
   
   float* devGradients = gradients(devTextons, nbins, blur, sigma, tgRadii, textonChoice);  
-  uint cueTimer;
-  cutCreateTimer(&cueTimer);
-  cutStartTimer(cueTimer);
+  StopWatchInterface *cueTimer=NULL;
+  sdkCreateTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   for(int scale = 0; scale < nscale; scale++) {
     int radius = tgRadii[scale];
     int length = 2*radius + 1;
     gpu_parabola(norients, width, height, border, &devGradients[borderWidth * borderHeight * norients * scale], radius, length, filters[scale], devTg + cuePitchInFloats * norients * scale, cuePitchInFloats);
   }
-  cutStopTimer(cueTimer);
-  printf(">+< \tTgsmooth: | %f | ms\n", cutGetTimerValue(cueTimer));
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tTgsmooth: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkDeleteTimer(&cueTimer);
 }
 
 
@@ -270,29 +273,28 @@ void localCues(int width, int height, float* devL, float* devA, float* devB, int
   gpu_parabola_init(norients, width, height, border);
 
   
-  uint cueTimer;
-  cutCreateTimer(&cueTimer);
-  cutStartTimer(cueTimer);
+  StopWatchInterface *cueTimer=NULL;
+  sdkCreateTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   bg(width, height, norients, nscale, &radii[0], &filters[0], devL, devBg, cuePitchInFloats, p_nTextonChoice);
-  cutStopTimer(cueTimer);
-  printf(">+< \tBg: | %f | ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tBg: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   cg(width, height, norients, nscale, &radii[1], &filters[1], devA, devCga, cuePitchInFloats, p_nTextonChoice);
-  cutStopTimer(cueTimer);
-  printf(">+< \tCga: | %f | ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tCga: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   cg(width, height, norients, nscale, &radii[1], &filters[1], devB, devCgb, cuePitchInFloats, p_nTextonChoice);
-  cutStopTimer(cueTimer);
-  printf(">+< \tCgb: | %f | ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
-  cutStartTimer(cueTimer);
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tCgb: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkResetTimer(&cueTimer);
+  sdkStartTimer(&cueTimer);
   tg(width, height, norients, nscale, &radii[1], &filters[1], devTextons, devTg, cuePitchInFloats, p_nTextonChoice);
-  cutStopTimer(cueTimer);
-  printf(">+< \tTg: | %f | ms\n", cutGetTimerValue(cueTimer));
-  cutResetTimer(cueTimer);
- 
+  sdkStopTimer(&cueTimer);
+  printf(">+< \tTg: | %f | ms\n", sdkGetTimerValue(&cueTimer));
+  sdkDeleteTimer(&cueTimer);
   cudaThreadSynchronize();
   finalizeGradients();
   gpu_parabola_cleanup();

--- a/localcues/rotate.64.cu
+++ b/localcues/rotate.64.cu
@@ -604,6 +604,7 @@ void dispatchGradient(int width, int height, int border, int nbins, float thetaP
   
   dim3 gridDim = dim3(width, 1);
   dim3 blockDim = dim3(nbins, UNROLL);
+  size_t sharedMemoryPerThread = 3 * UNROLL * sizeof(float);
  
   int hostRectangleOffsets[8];
   for(int i = 0; i < 8; i++) {
@@ -616,7 +617,7 @@ void dispatchGradient(int width, int height, int border, int nbins, float thetaP
   
   if (nbins == 25) {
     blockDim = dim3(32, UNROLL);
-    
+    const int nThreads = 48;
     int kernelRadius;
     int kernelLength;
     //float sigma = 0.10 * float(nbins);
@@ -629,11 +630,12 @@ void dispatchGradient(int width, int height, int border, int nbins, float thetaP
     //printf("Kernel length: %d, radius = %d\n", kernelLength, kernelRadius);
     cudaMemcpyToSymbol(blurKernel, hostKernel, sizeof(float) * kernelLength);
 
-    computeGradient<48, 25, true, false><<<gridDim, blockDim>>>(width, height, width * height, border, rotatedWidth, topNorm, bottomNorm, kernelRadius, kernelLength, devIntegrals, integralImagePitchInInts, devGradientA);
-    computeGradient<48, 25, true, true><<<gridDim, blockDim>>>(width, height, width * height, border, rotatedWidth, leftNorm, rightNorm, kernelRadius, kernelLength, devIntegrals, integralImagePitchInInts, devGradientB);
+    computeGradient<nThreads, 25, true, false><<<gridDim, blockDim, nThreads * sharedMemoryPerThread>>>(width, height, width * height, border, rotatedWidth, topNorm, bottomNorm, kernelRadius, kernelLength, devIntegrals, integralImagePitchInInts, devGradientA);
+    computeGradient<nThreads, 25, true, true><<<gridDim, blockDim, nThreads * sharedMemoryPerThread>>>(width, height, width * height, border, rotatedWidth, leftNorm, rightNorm, kernelRadius, kernelLength, devIntegrals, integralImagePitchInInts, devGradientB);
   } else if (nbins == 64) {
-    computeGradient<64, 64, false, false><<<gridDim, blockDim>>>(width, height, width * height, border, rotatedWidth, topNorm, bottomNorm, 0, 0, devIntegrals, integralImagePitchInInts, devGradientA);
-    computeGradient<64, 64, false, true><<<gridDim, blockDim>>>(width, height, width * height, border, rotatedWidth, leftNorm, rightNorm, 0, 0, devIntegrals, integralImagePitchInInts, devGradientB);
+    const int nThreads = 64;
+    computeGradient<nThreads, 64, false, false><<<gridDim, blockDim, nThreads * sharedMemoryPerThread>>>(width, height, width * height, border, rotatedWidth, topNorm, bottomNorm, 0, 0, devIntegrals, integralImagePitchInInts, devGradientA);
+    computeGradient<nThreads, 64, false, true><<<gridDim, blockDim, nThreads * sharedMemoryPerThread>>>(width, height, width * height, border, rotatedWidth, leftNorm, rightNorm, 0, 0, devIntegrals, integralImagePitchInInts, devGradientB);
   }
 }
 

--- a/noReorthog/Makefile
+++ b/noReorthog/Makefile
@@ -18,5 +18,5 @@ LINKCUFILES := stencilMVM.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/noReorthog/lanczosmain.cu
+++ b/noReorthog/lanczosmain.cu
@@ -3,6 +3,7 @@
 
 
 #include <cuda.h>
+#include <helper_image.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -47,7 +48,7 @@ int main(int argc, char** argv) {
   
   cudaMalloc((void**)&devMatrix, nDimension * nMatrixDimension * sizeof(float));
  
-	CUDA_SAFE_CALL(cudaMemcpy(devMatrix, hostMatrix, nMatrixDimension * nDimension * sizeof(float), cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(devMatrix, hostMatrix, nMatrixDimension * nDimension * sizeof(float), cudaMemcpyHostToDevice));
  
   struct timeval start;
   gettimeofday(&start, 0);
@@ -59,7 +60,7 @@ int main(int argc, char** argv) {
   generalizedEigensolve(myStencil, devMatrix, matrixPitchInFloats, getNEigs, &eigenValues, &devEigenVectors, fTolerance);
 
   float* eigenVectors = (float*)malloc(nMatrixDimension*sizeof(float)*getNEigs);
-  CUDA_SAFE_CALL(cudaMemcpy(eigenVectors, devEigenVectors, nMatrixDimension*getNEigs*sizeof(float), cudaMemcpyDeviceToHost));
+  checkCudaErrors(cudaMemcpy(eigenVectors, devEigenVectors, nMatrixDimension*getNEigs*sizeof(float), cudaMemcpyDeviceToHost));
   
 /*   initEigs(getNEigs, nMatrixDimension, &eigenValues, &eigenVectors); */
 
@@ -88,7 +89,7 @@ int main(int argc, char** argv) {
     fprintf(fp, "\n");
   }
   fclose(fp);
-  cutSavePGMf("eigvec1.pgm", eigenVectors+1*nMatrixDimension, width,height);
+  sdkSavePGM("eigvec1.pgm", eigenVectors+1*nMatrixDimension, width,height);
   
   fp = fopen("eigenValues.txt", "w");
 	for (int i = 0; i < getNEigs; i++) {

--- a/nonmax/Makefile
+++ b/nonmax/Makefile
@@ -17,5 +17,5 @@ LINKCUFILES :=
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/nonmax/nonmax.cu
+++ b/nonmax/nonmax.cu
@@ -1,6 +1,6 @@
 // vim: ts=4 syntax=cpp comments=
 
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <cuda.h>
 #include <fstream>
 #include <math.h>
@@ -95,14 +95,14 @@ __global__ void devFindMax(int p_nSize, size_t p_nPitch, float* p_aafPB, float* 
 
 void initCudaArrays(int p_nSize, float** p_devMaxPB, int** p_devOri)
 {
-	CUDA_SAFE_CALL(cudaMalloc((void**)p_devMaxPB, p_nSize * sizeof(float)));
-	CUDA_SAFE_CALL(cudaMalloc((void**)p_devOri, p_nSize * sizeof(int)));
+	checkCudaErrors(cudaMalloc((void**)p_devMaxPB, p_nSize * sizeof(float)));
+	checkCudaErrors(cudaMalloc((void**)p_devOri, p_nSize * sizeof(int)));
 }
 
 void freeCudaArrays(float* p_devMaxPB, int* p_devOri)
 {
-	CUDA_SAFE_CALL(cudaFree(p_devMaxPB));
-	CUDA_SAFE_CALL(cudaFree(p_devOri));
+	checkCudaErrors(cudaFree(p_devMaxPB));
+	checkCudaErrors(cudaFree(p_devOri));
 }
 
 
@@ -385,8 +385,8 @@ void nonMaxSuppression(int p_nWidth, int p_nHeight, float* p_devPB, int p_nDevPB
 	//printf("\nNow Pitch %d size =%d", p_nDevPBPitch, size);
 	devFindMax<<<gridDim, blockDim>>>(size, p_nDevPBPitch, p_devPB, devMaxPB, devOri);
 
-	//CUDA_SAFE_CALL(cudaMemcpy(maxpb, devMaxPB, size * sizeof(float), cudaMemcpyDeviceToHost));
-	//CUDA_SAFE_CALL(cudaMemcpy(ori, devOri, size * sizeof(int), cudaMemcpyDeviceToHost));
+	//checkCudaErrors(cudaMemcpy(maxpb, devMaxPB, size * sizeof(float), cudaMemcpyDeviceToHost));
+	//checkCudaErrors(cudaMemcpy(ori, devOri, size * sizeof(int), cudaMemcpyDeviceToHost));
 
 
 	struct timeval stopMax;
@@ -407,8 +407,8 @@ void nonMaxSuppression(int p_nWidth, int p_nHeight, float* p_devPB, int p_nDevPB
 
 	devOriented_2D<<<gridDim, blockDim>>>(p_nHeight, p_nWidth, devNMax);
 
-	CUDA_SAFE_CALL(cudaUnbindTexture(texMax));
-	CUDA_SAFE_CALL(cudaUnbindTexture(texOrient));
+	checkCudaErrors(cudaUnbindTexture(texMax));
+	checkCudaErrors(cudaUnbindTexture(texOrient));
 
 	freeCudaArrays(devMaxPB, devOri);
 

--- a/nonmax/nonmaxmain.cu
+++ b/nonmax/nonmaxmain.cu
@@ -1,7 +1,7 @@
 
 // vim: ts=4 syntax=cpp comments=
 
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <cuda.h>
 #include "nonmax.h"
 #include <stdio.h>
@@ -32,8 +32,8 @@ void chooseLargestGPU(bool verbose)
 void dummy()
 {
 	float* test;
-	CUDA_SAFE_CALL(cudaMalloc((void**)&test, 100 * sizeof(float)));
-	CUDA_SAFE_CALL(cudaFree(test));
+	checkCudaErrors(cudaMalloc((void**)&test, 100 * sizeof(float)));
+	checkCudaErrors(cudaFree(test));
 }
 
 void PrintMatrix(char* filename, int p_nWidth, int p_nHeight, float* p_aaMatrix)
@@ -87,23 +87,23 @@ int main(int argc, char** argv)
 	float* devpb = 0;
 	size_t pitch = 0;
 	int size = width * height;
-	CUDA_SAFE_CALL(cudaMallocPitch((void**)&devpb, &pitch, size *  sizeof(float), 8));
+	checkCudaErrors(cudaMallocPitch((void**)&devpb, &pitch, size *  sizeof(float), 8));
 	pitch/=sizeof(float);
 	for (int i = 0; i < 8; i++)
 	{
-		CUDA_SAFE_CALL(cudaMemcpy((devpb)+i*pitch, pb+i*size, size * sizeof(float), cudaMemcpyHostToDevice));
+		checkCudaErrors(cudaMemcpy((devpb)+i*pitch, pb+i*size, size * sizeof(float), cudaMemcpyHostToDevice));
 	}
 	float* devNMax = 0;
-	CUDA_SAFE_CALL(cudaMalloc((void**)&devNMax, size * sizeof(float)));
+	checkCudaErrors(cudaMalloc((void**)&devNMax, size * sizeof(float)));
 
 	nonMaxSuppression(width, height, devpb, pitch, devNMax);
 
 	float* nmax = 0;
 	nmax = (float*)malloc(sizeof(float)*size);
-	CUDA_SAFE_CALL(cudaMemcpy(nmax, devNMax, size * sizeof(float), cudaMemcpyDeviceToHost));
+	checkCudaErrors(cudaMemcpy(nmax, devNMax, size * sizeof(float), cudaMemcpyDeviceToHost));
 
-	CUDA_SAFE_CALL(cudaFree(devNMax));
-	CUDA_SAFE_CALL(cudaFree(devpb));
+	checkCudaErrors(cudaFree(devNMax));
+	checkCudaErrors(cudaFree(devpb));
 
 	PrintMatrix("nmax.txt", width, height, nmax);
 	

--- a/postprocess/Makefile
+++ b/postprocess/Makefile
@@ -13,6 +13,6 @@ CUFILES		:= postprocessmain.cu skeleton.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk
 

--- a/postprocess/postprocessmain.cu
+++ b/postprocess/postprocessmain.cu
@@ -37,17 +37,17 @@ void skeletonTest()
 
 
     float* devGPb, *devGPb_thin, *devMPb;
-    CUDA_SAFE_CALL(cudaMalloc((void**)&devGPb,nPixels*sizeof(float)));
-    CUDA_SAFE_CALL(cudaMalloc((void**)&devGPb_thin,nPixels*sizeof(float)));
-    CUDA_SAFE_CALL(cudaMalloc((void**)&devMPb,nPixels*sizeof(float)));
+    checkCudaErrors(cudaMalloc((void**)&devGPb,nPixels*sizeof(float)));
+    checkCudaErrors(cudaMalloc((void**)&devGPb_thin,nPixels*sizeof(float)));
+    checkCudaErrors(cudaMalloc((void**)&devMPb,nPixels*sizeof(float)));
 
-    CUDA_SAFE_CALL(cudaMemcpy(devGPb, in, nPixels*sizeof(float), cudaMemcpyHostToDevice));
-    CUDA_SAFE_CALL(cudaMemcpy(devGPb_thin, devGPb , nPixels*sizeof(float), cudaMemcpyDeviceToDevice));
-    CUDA_SAFE_CALL(cudaMemcpy(devMPb, devGPb , nPixels*sizeof(float), cudaMemcpyDeviceToDevice));
+    checkCudaErrors(cudaMemcpy(devGPb, in, nPixels*sizeof(float), cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMemcpy(devGPb_thin, devGPb , nPixels*sizeof(float), cudaMemcpyDeviceToDevice));
+    checkCudaErrors(cudaMemcpy(devMPb, devGPb , nPixels*sizeof(float), cudaMemcpyDeviceToDevice));
 
     PostProcess(width, height, width , devGPb, devMPb , devGPb_thin);
 
-    CUDA_SAFE_CALL(cudaMemcpy(out, devGPb_thin,  nPixels*sizeof(float), cudaMemcpyDeviceToHost));
+    checkCudaErrors(cudaMemcpy(out, devGPb_thin,  nPixels*sizeof(float), cudaMemcpyDeviceToHost));
     printf("GPU OUT\n");
     for(int y=0;y<height;y++)
     {
@@ -62,9 +62,9 @@ void skeletonTest()
     delete [] out;
     delete [] lut;
 
-    CUDA_SAFE_CALL(cudaFree(devGPb));
-    CUDA_SAFE_CALL(cudaFree(devMPb));
-    CUDA_SAFE_CALL(cudaFree(devGPb_thin));
+    checkCudaErrors(cudaFree(devGPb));
+    checkCudaErrors(cudaFree(devMPb));
+    checkCudaErrors(cudaFree(devGPb_thin));
 }
 
 int main()

--- a/postprocess/skeleton.h
+++ b/postprocess/skeleton.h
@@ -1,5 +1,5 @@
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <stdio.h>
 
 #define NUM_LUTS 8

--- a/sPb/Makefile
+++ b/sPb/Makefile
@@ -18,5 +18,5 @@ LINKCUFILES := convert.cu
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/sPb/spbmain.cu
+++ b/sPb/spbmain.cu
@@ -2,7 +2,7 @@
 
 #include "spectralPb.h"
 #include <stdio.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <cuda.h>
 
 void chooseLargestGPU(bool verbose) {
@@ -52,17 +52,17 @@ int main(int argc, char** argv)
 	fclose(fvector);
 
 	float* devEigVec = 0;
-	CUDA_SAFE_CALL(cudaMalloc((void**)&devEigVec, width*height*nvec*sizeof(float)));
-	CUDA_SAFE_CALL(cudaMemcpy(devEigVec, eigvector, width*height*nvec*sizeof(float), cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMalloc((void**)&devEigVec, width*height*nvec*sizeof(float)));
+	checkCudaErrors(cudaMemcpy(devEigVec, eigvector, width*height*nvec*sizeof(float), cudaMemcpyHostToDevice));
 
 	float* devResult = 0;
 	size_t pitch = 0;
-	CUDA_SAFE_CALL(cudaMallocPitch((void**)&devResult, &pitch, size *  sizeof(float), 8));
+	checkCudaErrors(cudaMallocPitch((void**)&devResult, &pitch, size *  sizeof(float), 8));
 	pitch/=sizeof(float);
-	printf("pitch value %d", pitch);
+	printf("pitch value %zu", pitch);
 	spectralPb(eigvalue, devEigVec, width, height, nvec, devResult, pitch);
 	float* hostResult = (float*) malloc(sizeof(float)*pitch*8);
-	CUDA_SAFE_CALL(cudaMemcpy(hostResult, devResult, sizeof(float)*pitch*8, cudaMemcpyDeviceToHost) );
+	checkCudaErrors(cudaMemcpy(hostResult, devResult, sizeof(float)*pitch*8, cudaMemcpyDeviceToHost) );
 
 	for (int i = 0; i < 8 ; i++)
 	{
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
 		printf("\n");
 	}
 
-	CUDA_SAFE_CALL(cudaFree(devResult));
+	checkCudaErrors(cudaFree(devResult));
 	free(eigvector);
 	free(eigvalue);
 }

--- a/stencilMatrixMultiply/Makefile
+++ b/stencilMatrixMultiply/Makefile
@@ -17,5 +17,5 @@ LINKCUFILES :=
 ################################################################################
 # Rules and targets
 
-SMVERSIONFLAGS := -arch sm_10
+SMVERSIONFLAGS := -arch sm_35
 include ../common.mk

--- a/stencilMatrixMultiply/common.mk
+++ b/stencilMatrixMultiply/common.mk
@@ -12,7 +12,7 @@ ifdef cuda-install
 	CUDA_INSTALL_PATH := $(cuda-install)
 endif
 
-CUDA_SDK_PATH ?= $(HOME)/cuda
+CUDA_SDK_PATH ?= /usr/local/cuda/samples
 
 # Basic directory setup for SDK
 # (override directories only if they are not already defined)
@@ -24,7 +24,7 @@ ROOTOBJDIR ?= $(ROOTDIR)/obj
 ROOTSODIR  ?= $(ROOTDIR)/lib
 SODIR      ?= $(ROOTSODIR)/linux
 
-LIBDIR     := $(CUDA_SDK_PATH)/lib 
+LIBDIR     := $(CUDA_SDK_PATH)/common/lib
 COMMONDIR  := $(CUDA_SDK_PATH)/common
 
 # Compilers
@@ -56,7 +56,7 @@ ifeq ($(USEGLLIB),1)
 endif
 
 # Libs
-LIB       := -L$(CUDA_INSTALL_PATH)/lib -L$(LIBDIR) -L$(COMMONDIR)/lib -lcuda -lcudart -lblas ${OPENGLLIB} ${LIB}
+LIB       := -L$(CUDA_INSTALL_PATH)/lib -L$(LIBDIR) -L$(COMMONDIR)/lib -L$(ROOTSODIR) -lcuda -lcudart -lblas ${OPENGLLIB} ${LIB}
 
 # Warning flags
 CXXWARN_FLAGS := \
@@ -147,7 +147,7 @@ ifneq ($(STATIC_LIB),)
 	TARGET   := $(subst .a,$(LIBSUFFIX).a,$(LIBDIR)/$(STATIC_LIB))
 	LINKLINE  = ar qv $(TARGET) $(OBJS) 
 else
-	LIB += -lcutil$(LIBSUFFIX)
+	#LIB += -lcutil$(LIBSUFFIX)
 	# Device emulation configuration
 	ifeq ($(emu), 1)
 		NVCCFLAGS   += -deviceemu

--- a/stencilMatrixMultiply/stencilMVM.cu
+++ b/stencilMatrixMultiply/stencilMVM.cu
@@ -1,6 +1,6 @@
 // vim: ts=4 syntax=cpp comments=
 
-#include <cuda.h>
+#include <helper_cuda.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -215,7 +215,7 @@ __global__ void generalizeVectors(int nPixels, int nVectors, float* devVectors, 
 int findPitchInFloats(int width) {
   float* test;
   size_t pitch;
-  CUDA_SAFE_CALL(cudaMallocPitch((void**)&test, &pitch, width * sizeof(float), 1));
+  checkCudaErrors(cudaMallocPitch((void**)&test, &pitch, width * sizeof(float), 1));
   cudaFree(test);
   return pitch/sizeof(float);
 }
@@ -243,9 +243,9 @@ float* convertMatrix(Stencil* theStencil, dim3 gridDim, dim3 blockDim, int nDime
   cudaMemcpyToSymbol(constOffsets, hostConstOffsets, sizeof(hostConstOffsets));
 
   float* devSum;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devSum, width * sizeof(float) * height));
+  checkCudaErrors(cudaMalloc((void**)&devSum, width * sizeof(float) * height));
   float* devRSqrtSum;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devRSqrtSum, width * sizeof(float) * height));
+  checkCudaErrors(cudaMalloc((void**)&devRSqrtSum, width * sizeof(float) * height));
 
   
   int nDimUnroll = findNDimUnroll(nDimension);
@@ -254,7 +254,7 @@ float* convertMatrix(Stencil* theStencil, dim3 gridDim, dim3 blockDim, int nDime
 /*   /\* float* hostSum = (float*)malloc(width * height * sizeof(float)); *\/ */
 /* /\*   memset(hostSum, 0, width * height * sizeof(float)); *\/ */
 
-/* /\*   CUDA_SAFE_CALL(cudaMemcpy(hostSum, devSum, width * sizeof(float) * height, cudaMemcpyDeviceToHost)); *\/ */
+/* /\*   checkCudaErrors(cudaMemcpy(hostSum, devSum, width * sizeof(float) * height, cudaMemcpyDeviceToHost)); *\/ */
 /* /\*   for(int row = 0; row < height; row++) { *\/ */
 /* /\*     for (int col = 0; col < width; col++) { *\/ */
 /* /\*       printf("%f ", hostSum[row * width + col]); *\/ */
@@ -268,7 +268,7 @@ float* convertMatrix(Stencil* theStencil, dim3 gridDim, dim3 blockDim, int nDime
 
 /* insert stuff here  
   float* hostMatrix = new float[matrixPitchInFloats*nDimension];
-  CUDA_SAFE_CALL(cudaMemcpy(hostMatrix, devMatrix, matrixPitchInFloats * sizeof(float) * nDimension, cudaMemcpyDeviceToHost)); 
+  checkCudaErrors(cudaMemcpy(hostMatrix, devMatrix, matrixPitchInFloats * sizeof(float) * nDimension, cudaMemcpyDeviceToHost)); 
  
    printf("Writing matrix to file ...\n");
    FILE* fpw = fopen("ungeneralized.sma", "w"); 
@@ -405,10 +405,10 @@ insert ends */
 /*   memset(hostSum, 0, width * height * sizeof(float)); */
   /* float* devSum; */
 /*   size_t devSumPitch; */
-/*   CUDA_SAFE_CALL(cudaMallocPitch((void**)&devSum, &devSumPitch, width *sizeof(float), height)); */
+/*   checkCudaErrors(cudaMallocPitch((void**)&devSum, &devSumPitch, width *sizeof(float), height)); */
 /*   stencilSumRows<<<gridDim, blockDim>>>(width, height, nPixels, radius, nDimension, devMatrix, widthPitchInFloats, devSum); */
 
- /*  CUDA_SAFE_CALL(cudaMemcpy2D(hostSum, width * sizeof(float), devSum, devSumPitch, width*sizeof(float), height, cudaMemcpyDeviceToHost)); */
+ /*  checkCudaErrors(cudaMemcpy2D(hostSum, width * sizeof(float), devSum, devSumPitch, width*sizeof(float), height, cudaMemcpyDeviceToHost)); */
 /*   for(int row = 0; row < height; row++) { */
 /*     for (int col = 0; col < width; col++) { */
 /*       printf("%f ", hostSum[row * width + col]); */
@@ -419,7 +419,7 @@ insert ends */
   
 //  unGeneralizeMatrix<<<gridDim, blockDim>>>(width, height, nPixels, radius, nDimension, devMatrix, widthPitchInFloats, devSum);
 
-  /* CUDA_SAFE_CALL(cudaMemcpy(hostMatrix, devMatrix, matrixPitchInFloats * sizeof(float) * nDimension, cudaMemcpyDeviceToHost)); */
+  /* checkCudaErrors(cudaMemcpy(hostMatrix, devMatrix, matrixPitchInFloats * sizeof(float) * nDimension, cudaMemcpyDeviceToHost)); */
   
 /*   FILE* fpw = fopen("ungeneralized.sma", "w"); */
 /*   fwrite(&nPixels, sizeof(int), 1, fpw); */

--- a/textons/common.mk
+++ b/textons/common.mk
@@ -82,7 +82,7 @@ CWARN_FLAGS := $(CXXWARN_FLAGS) \
 	-Wmain \
 
 # Compiler-specific flags
-NVCCFLAGS := -arch sm_12 -Xptxas -v
+NVCCFLAGS := -arch sm_35 -Xptxas -v
 CXXFLAGS  := $(CXXWARN_FLAGS)
 CFLAGS    := $(CWARN_FLAGS)
 

--- a/textons/filters.cpp
+++ b/textons/filters.cpp
@@ -292,7 +292,9 @@ void gaussian_2D(
    float* mrotate = new float[(2*support_x + 1)*(2*support_y + 1)];
    compute_rotate_2D(m, mrotate, mx_size, my_size, 2*support_x + 1, 2*support_y + 1, ori);
 
-   delete [] m,mx,my;
+   delete [] m;
+   delete [] mx;
+   delete [] my;
    m = mrotate;
    int size=(2*support_x + 1)*(2*support_y + 1);
    //m = rotate_2D_crop(m, ori, 2*support_x + 1, 2*support_y + 1);

--- a/textons/kmeans.cu
+++ b/textons/kmeans.cu
@@ -1,5 +1,5 @@
 #include <cuda.h>
-#include <cutil.h>
+#include <helper_cuda.h>
 #include "kmeans.h"
 #include <cublas.h>
 #include <stdio.h>
@@ -600,7 +600,8 @@ void testSgemm() {
 */
 
 int kmeans(int textonChoice, int nPixels, int width, int height, int clusterCount, int filterCount, float* devResponses, int** p_devClusters, int maxIter, int convThresh) {
-  printf("Beginning kmeans\n", maxIter);
+  //printf("Beginning kmeans\n", maxIter);
+  printf("Beginning kmeans\n");
   dim3 gridDim = dim3((width - 1)/XBLOCK + 1, (height - 1)/YBLOCK + 1);
   dim3 blockDim = dim3(XBLOCK, YBLOCK);
 
@@ -635,31 +636,31 @@ int kmeans(int textonChoice, int nPixels, int width, int height, int clusterCoun
 #endif
 
   int* devCentroidMass;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devCentroidMass, sizeof(int) * filterCount * clusterCount* afCopies));
+  checkCudaErrors(cudaMalloc((void**)&devCentroidMass, sizeof(int) * filterCount * clusterCount* afCopies));
   unsigned int* devCentroidCount;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devCentroidCount, sizeof(unsigned int) * filterCount * clusterCount* afCopies));
+  checkCudaErrors(cudaMalloc((void**)&devCentroidCount, sizeof(unsigned int) * filterCount * clusterCount* afCopies));
   float* devCentroids;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devCentroids, sizeof(float) * filterCount * clusterCount));
+  checkCudaErrors(cudaMalloc((void**)&devCentroids, sizeof(float) * filterCount * clusterCount));
   int* devChanges;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devChanges, sizeof(int)));
+  checkCudaErrors(cudaMalloc((void**)&devChanges, sizeof(int)));
 
   float* devPointsDots;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devPointsDots, sizeof(int) * nPixels));
+  checkCudaErrors(cudaMalloc((void**)&devPointsDots, sizeof(int) * nPixels));
   float* devCentroidsDots;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devCentroidsDots, sizeof(int) * clusterCount));
+  checkCudaErrors(cudaMalloc((void**)&devCentroidsDots, sizeof(int) * clusterCount));
   makeSelfDots<<<linearGrid, linearBlock>>>(devResponses, nPixels, devPointsDots, nPixels, filterCount);
 
   float* devDist;
   size_t devDistPitch;
-  CUDA_SAFE_CALL(cudaMallocPitch((void**)&devDist, &devDistPitch, sizeof(float) * nPixels, clusterCount));
+  checkCudaErrors(cudaMallocPitch((void**)&devDist, &devDistPitch, sizeof(float) * nPixels, clusterCount));
   int devDistPitchInFloats = devDistPitch/sizeof(float);
 
   int i;
   int hostChanges;
   for(i = 0; i < maxIter; i++) {
-    CUDA_SAFE_CALL(cudaMemset(devCentroidMass, 0, sizeof(int) * filterCount * clusterCount* afCopies));
-    CUDA_SAFE_CALL(cudaMemset(devCentroidCount, 0, sizeof(int) * clusterCount* afCopies));
-    CUDA_SAFE_CALL(cudaMemset(devChanges, 0, sizeof(int)));
+    checkCudaErrors(cudaMemset(devCentroidMass, 0, sizeof(int) * filterCount * clusterCount* afCopies));
+    checkCudaErrors(cudaMemset(devCentroidCount, 0, sizeof(int) * clusterCount* afCopies));
+    checkCudaErrors(cudaMemset(devChanges, 0, sizeof(int)));
     
 #ifndef __NO_ATOMIC
 
@@ -707,7 +708,7 @@ int kmeans(int textonChoice, int nPixels, int width, int height, int clusterCoun
     }
     findSgemmLabels(devResponses, nPixels, nPixels, devCentroids, clusterCount, clusterCount, filterCount, devPointsDots, devCentroidsDots, devDist, devDistPitchInFloats, devClusters, devChanges);
 
-    CUDA_SAFE_CALL(cudaMemcpy(&hostChanges, devChanges, sizeof(int), cudaMemcpyDeviceToHost));
+    checkCudaErrors(cudaMemcpy(&hostChanges, devChanges, sizeof(int), cudaMemcpyDeviceToHost));
     printf("\tChanges: %d\n", hostChanges);
     if (hostChanges <= convThresh) {
       break;

--- a/textons/texton.64.cu
+++ b/textons/texton.64.cu
@@ -1,7 +1,7 @@
 #include <cuda.h>
 #include "filters.h"
 #include "kmeans.h"
-#include <cutil.h>
+#include <helper_cuda.h>
 #include <stdio.h>
 
 texture<float, 2, cudaReadModeElementType> image;
@@ -88,15 +88,15 @@ void findTextons(int width, int height, float* devImage, int** p_devTextons) {
 //  }
 //  delete[] f;
 
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devResponses, sizeof(float)*nPixels*filterCount));
-  //CUDA_SAFE_CALL(cudaMemcpyToSymbol(radii, hRadii, sizeof(hRadii)));
-  CUDA_SAFE_CALL(cudaMemcpyToSymbol(radii, hRadii, filterCount*sizeof(int)));
-  //CUDA_SAFE_CALL(cudaMemcpyToSymbol(coefficients, hCoefficients, sizeof(hCoefficients)));
-  //CUDA_SAFE_CALL(cudaMemcpyToSymbol(coefficients, hCoefficients, nFilterCoefficients* sizeof(float)));
+  checkCudaErrors(cudaMalloc((void**)&devResponses, sizeof(float)*nPixels*filterCount));
+  //checkCudaErrors(cudaMemcpyToSymbol(radii, hRadii, sizeof(hRadii)));
+  checkCudaErrors(cudaMemcpyToSymbol(radii, hRadii, filterCount*sizeof(int)));
+  //checkCudaErrors(cudaMemcpyToSymbol(coefficients, hCoefficients, sizeof(hCoefficients)));
+  //checkCudaErrors(cudaMemcpyToSymbol(coefficients, hCoefficients, nFilterCoefficients* sizeof(float)));
   
   float* devcoefficients;
-  CUDA_SAFE_CALL(cudaMalloc((void**)&devcoefficients, nFilterCoefficients* sizeof(float)));
-  CUDA_SAFE_CALL(cudaMemcpy(devcoefficients, hCoefficients, nFilterCoefficients* sizeof(float), cudaMemcpyHostToDevice));
+  checkCudaErrors(cudaMalloc((void**)&devcoefficients, nFilterCoefficients* sizeof(float)));
+  checkCudaErrors(cudaMemcpy(devcoefficients, hCoefficients, nFilterCoefficients* sizeof(float), cudaMemcpyHostToDevice));
 
   cudaChannelFormatDesc channelMax = cudaCreateChannelDesc<float>();
   size_t offset = 0;
@@ -104,9 +104,9 @@ void findTextons(int width, int height, float* devImage, int** p_devTextons) {
   
   cudaArray* imageArray;
   cudaChannelFormatDesc floatTex = cudaCreateChannelDesc<float>();
-  CUDA_SAFE_CALL(cudaMallocArray(&imageArray, &floatTex, width, height));
-  CUDA_SAFE_CALL(cudaMemcpyToArray(imageArray, 0, 0, devImage, nPixels * sizeof(float), cudaMemcpyDeviceToDevice));
-  CUDA_SAFE_CALL(cudaBindTextureToArray(image, imageArray));
+  checkCudaErrors(cudaMallocArray(&imageArray, &floatTex, width, height));
+  checkCudaErrors(cudaMemcpyToArray(imageArray, 0, 0, devImage, nPixels * sizeof(float), cudaMemcpyDeviceToDevice));
+  checkCudaErrors(cudaBindTextureToArray(image, imageArray));
   printf("Convolving\n");
   dim3 gridDim = dim3((width - 1)/XBLOCK + 1, (height - 1)/YBLOCK + 1);
   dim3 blockDim = dim3(XBLOCK, YBLOCK);
@@ -115,8 +115,8 @@ void findTextons(int width, int height, float* devImage, int** p_devTextons) {
   
   kmeans(nPixels, width, height, clusterCount, filterCount, devResponses, p_devTextons);
  
-  CUDA_SAFE_CALL(cudaFreeArray(imageArray));
-  CUDA_SAFE_CALL(cudaFree(devResponses));
+  checkCudaErrors(cudaFreeArray(imageArray));
+  checkCudaErrors(cudaFree(devResponses));
 
   free(hRadii);
   free(hCoefficients);


### PR DESCRIPTION
I've migrated all API calls to the new CUDA SDK, and fixed the illegal memory access issue (#2). The program runs successfully on Ubuntu 14.04 with a Tesla K20 GPU. The run time is about 2 seconds when given the default Polynesia image.

For it to work, I'd to create two symlinks - one file at `./lib/libblas.so` which points to `/usr/lib/libblas.so.3` since BLAS wasn't being detected, and another directory at `./lib/acml` which points to the location for the uncompressed [ACML](http://developer.amd.com/tools-and-sdks/archive/compute/amd-core-math-library-acml/acml-downloads-resources/) package. Additionally, I'd to also set the dynamic library path for it to detect ACML, by adding `export LD_LIBRARY_PATH="$HOME/acml5.3.1/ifort64/lib/:$LD_LIBRARY_PATH"` to my bashrc.
```
abcherun@gpus5:~/dev/damascene<update_cuda_runtime>$ ./bin/linux/release/damascene damascene/polynesia.ppm
Using cuda device 1: Tesla K20c
Processing: damascene/polynesia.ppm, output in damascene/polynesiaPb.pgm and damascene/polynesia.pb

Eig 9 Tol 0.001000 Texton 1
Image found: 321 x 481 pixels
Available 246022144 bytes on GPU
>+< rgbUtoGrayF | 0.733000 | ms
Convolving
Beginning kmeans
	Changes: 189059
	Changes: 82140
	Changes: 53169
	Changes: 40551
	Changes: 32645
	Changes: 25978
	Changes: 23274
	Changes: 19205
	Changes: -215195205
	8 iterations until termination
Kmeans completed
>+< texton | 330.005005 | ms
>+< rgbUtoLab3F | 1.980000 | ms
>+< normalizeLab | 0.015000 | ms
>+< mirrorImage | 0.988000 | ms
Beginning Local cues computation
>+< 	Bgsmooth: | 13.919000 | ms
>+< 	Bg: | 89.497002 | ms
>+< 	Cgsmooth: | 28.606001 | ms
>+< 	Cga: | 101.626999 | ms
>+< 	Cgsmooth: | 28.462000 | ms
>+< 	Cgb: | 100.380997 | ms
>+< 	Tgsmooth: | 26.927000 | ms
>+< 	Tg: | 79.556999 | ms
Completed Local cues
localcues time: 0.378023 seconds
>+< localcues | 378.028992 | ms
>+< combine | 1.131000 | ms

Max time: 0.001299 seconds
Oriented Max time: 0.000520 seconds
Solve time: 0.001848 seconds
>+< nonmaxsupression | 3.734000 | ms
Intervening contour completed
>+< intervene | 16.999001 | ms
Available 160432128 bytes on GPU
Can fit 220 iterations on GPU
lanczos iteration: 0
lanczos iteration: 100
lanczos iteration: 200
Screened Eigenvalues:
8.746726e-08 1.220966e-04 2.492128e-04 6.079139e-04 1.203148e-03 1.603140e-03 2.338310e-03 3.313430e-03 4.052723e-03
Eigenvalue: 8 has too large a residual 2.778898e-03
lanczos iteration: 300
lanczos iteration: 400
Screened Eigenvalues:
8.522160e-08 4.413837e-05 1.205699e-04 2.042214e-04 2.480132e-04 3.003473e-04 4.872549e-04 6.106148e-04 7.674522e-04
Eigenvalue: 8 has too large a residual 1.742319e-03
lanczos iteration: 500
lanczos iteration: 600
lanczos iteration: 700
lanczos iteration: 800
lanczos iteration: 900
Screened Eigenvalues:
6.426722e-08 4.418454e-05 1.360216e-04 2.063825e-04 2.494206e-04 2.955018e-04 4.003884e-04 4.659711e-04 5.760831e-04
Converged
nIterations = 1000
lanczos Iterations : 1.226173 seconds
Eigenvector calculation: 194.000000 microseconds
>+< generalizedEigensolve | 1243.982056 | ms
>+< spectralPb | 4.027000 | ms
>+< StartCalcGpb | 1.020000 | ms
Skeletonizing ...
	Iteration = 1, Image changed
	Iteration = 2, Image changed
	Iteration = 3, Image unchanged
CUDA Status : no error
>+< PostProcess | 4.072000 | ms
>+< Computation time: | 1.986825 | seconds
```
Do remember to squash the commits before merging :)